### PR TITLE
MakeFile added

### DIFF
--- a/MakeFile
+++ b/MakeFile
@@ -1,0 +1,2 @@
+texty : texty.c
+	$(CC) texty.c -o texty -Wall -Wextra -pedantic -std=c17


### PR DESCRIPTION
MakeFile is added.
It will be used by typing `make texty` in the shell. The executable is named `texty`. C17 standard is being followed with warning flags.